### PR TITLE
Fix for Django 1.8 and Python 3

### DIFF
--- a/django_password_protect/password_protect_middleware.py
+++ b/django_password_protect/password_protect_middleware.py
@@ -1,6 +1,7 @@
 from django.http import HttpResponse
 from django.conf import settings
 
+import base64
 import django
 
 PASSWORD_PROTECT = getattr(settings, 'PASSWORD_PROTECT', True)
@@ -18,13 +19,14 @@ class PasswordProtectMiddleware(object):
             authentication = request.META['HTTP_AUTHORIZATION']
             auth_method, auth_credentials = authentication.split(' ', 1)
             if auth_method.lower() == 'basic':
-                username, password = auth_credentials.strip().decode('base64').split(':', 1)
+                auth_credentials = base64.decodestring(auth_credentials.strip().encode('ascii')).decode('ascii')
+                username, password = auth_credentials.split(':', 1)
                 if (username == settings.PASSWORD_PROTECT_USERNAME) and \
                    (password == settings.PASSWORD_PROTECT_PASSWORD):
                     return
 
         html = "<html><title>Auth required</title><body><h1>Authorization Required</h1></body></html>"
-        if django.VERSION < 1.5:
+        if django.VERSION < (1, 5):
             response_args = {'mimetype': 'text/html'}
         else:
             response_args = {'content_type': 'text/html'}


### PR DESCRIPTION
* Python 3 base64 decoding works on bytes, not strings
* Django.VERSION is a tuple, so need to compare element-wise